### PR TITLE
fix: use STS credential in poll_for_oauth2_token

### DIFF
--- a/agent_identity_python_sdk/setup.py
+++ b/agent_identity_python_sdk/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="agent_identity_python_sdk",
-    version="0.1.4",
+    version="0.1.5",
     description="Python SDK for using Agent Identity Service",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/agent_identity_python_sdk/src/agent_identity_python_sdk/__init__.py
+++ b/agent_identity_python_sdk/src/agent_identity_python_sdk/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"
 
 from .context import AgentIdentityContext
 from .core import requires_access_token, requires_sts_token, requires_api_key, requires_workload_access_token

--- a/agent_identity_python_sdk/src/agent_identity_python_sdk/core/identity.py
+++ b/agent_identity_python_sdk/src/agent_identity_python_sdk/core/identity.py
@@ -260,7 +260,7 @@ class IdentityClient:
                 request.session_uri = response_body.session_uri
 
             if poll_for_token:
-                return await self.poll_for_oauth2_token(request)
+                return await self.poll_for_oauth2_token(request, credential=credential)
             else:
                 raise RuntimeError("Agent Identity service returned an authorization URL, authorization flow needs to be completed.")
 
@@ -365,24 +365,34 @@ class IdentityClient:
         )
 
 
-    async def poll_for_oauth2_token(self, request: GetResourceOAuth2TokenRequest, max_retries: int = 20, delay_sec: float = 3.0) -> str:
+    async def poll_for_oauth2_token(self, request: GetResourceOAuth2TokenRequest, max_retries: int = 20, delay_sec: float = 3.0, credential: Optional[CredentialClient] = None) -> str:
 
         """
         Poll the GetResourceOAuth2Token endpoint until a token is obtained or maximum retries are reached
-        
+
         Args:
             request: GetResourceOAuth2TokenRequest object
 
             max_retries: Maximum number of retry attempts
 
             delay_sec: Delay in seconds between each retry
-            
+
+            credential: Optional credential for fetching the token. Used when use_sts is enabled.
+
         Returns:
             Returns the access token on success, throws an exception on failure
         """
+        client = self.data_client
+        if self.use_sts:
+            client = DataClient(config=open_api_models.Config(
+                credential=credential,
+                region_id=self.region_id,
+                endpoint=self.data_api_endpoint or f"agentidentitydata.{self.region_id}.aliyuncs.com"
+            ))
+
         for attempt in range(max_retries):
             try:
-                response = self.data_client.get_resource_oauth2_token(request)
+                response = client.get_resource_oauth2_token(request)
                 access_token = response.body.access_token
 
                 if access_token:


### PR DESCRIPTION
## Summary

- Fix a bug in `poll_for_oauth2_token` where it always used `self.data_client` (default credential) instead of the STS credential when `use_sts` is enabled. This caused credential inconsistency between the initial OAuth2 token request and the polling phase.
- Bump SDK version to `0.1.5`.

## Test plan

- [x] All 129 tests pass
- [x] Code coverage at 99%

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>